### PR TITLE
Fixed a problem under wp 3.4.2

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -247,7 +247,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
     if (!is_admin())
     {
       do_action('wp-less_init', $this);
-      add_action('wp', array($this, 'processStylesheets'), 999, 0);
+      add_action('wp_enqueue_scripts', array($this, 'processStylesheets'), 999, 0);
       add_filter('wp-less_stylesheet_save', array($this, 'filterStylesheetUri'), 10, 2);
     }
     else


### PR DESCRIPTION
I found there's a serious problem that it doesn't work under the new version of wordpress.

The hook should better to attached on 'wp_enqueue_scripts' than just 'wp', which will set the plugin to process before everything, and the queueing of scripts and stylesheets by theme is not done yet at the time.

Didn't test on older versions of wordpress, but those shall work as will.
