### PR TITLE
Not working on SSL

### DIFF
--- a/lib/vendor/plugin-toolkit/BaseConfiguration.class.php
+++ b/lib/vendor/plugin-toolkit/BaseConfiguration.class.php
@@ -284,7 +284,7 @@ abstract class WPPluginToolkitConfiguration
       if (!$url = get_option( 'upload_url_path'))
       {
         $url = (empty($upload_path) or ($upload_path == $dir))
-                ? WP_CONTENT_URL . '/uploads'
+                ? content_url() . '/uploads'
                 : trailingslashit($siteurl).$upload_path;
       }
     }


### PR DESCRIPTION
WP-LESS stopped working on SSL (maybe with recent updates?). I think WP_CONTENT_URL needs to be converted to content_url() here, too?
