### PR TITLE
Wrong cache busting calculation in deep mode

### DIFF
--- a/lib/Compiler.class.php
+++ b/lib/Compiler.class.php
@@ -77,6 +77,7 @@ class WPLessCompiler extends lessc
 		// saving compiled stuff
 		if (isset($compiled_cache['compiled']) && $compiled_cache['compiled'])
 		{
+      $stylesheet->setSourceTimestamp($compiled_cache['updated']);
 			$this->saveStylesheet($stylesheet, $compiled_cache['compiled']);
 
 			$compiled_cache['compiled'] = NULL;

--- a/lib/Stylesheet.class.php
+++ b/lib/Stylesheet.class.php
@@ -89,7 +89,7 @@ class WPLessStylesheet
     $this->target_path =    self::$upload_dir.$target_file;
     $this->target_uri =     self::$upload_uri.$target_file;
 
-    $this->source_timestamp = filemtime($this->source_path);
+    $this->setSourceTimestamp(filemtime($this->source_path));
   }
 
   /**
@@ -197,5 +197,17 @@ class WPLessStylesheet
   public function save()
   {
     $this->is_new = false;
+  }
+
+  /**
+   * Sets the source timestamp of the file
+   * Mostly used to generate a proper cache busting URI
+   *
+   * @since 1.5.2
+   * @param integer $timestamp
+   */
+  public function setSourceTimestamp($timestamp)
+  {
+    $this->source_timestamp = $timestamp;
   }
 }


### PR DESCRIPTION
Even if we change a subfile, the unique ID used for client-side cache is based on the root file.
