### PR TITLE
Call to a Member Function on a Non-object

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,7 +14,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wp-less/
 if (!class_exists('WPLessPlugin'))
 {
 	require dirname(__FILE__).'/lib/Plugin.class.php';
-	$WPLessPlugin = WPPluginToolkitPlugin::create('WPLess', __FILE__);
+	$WPLessPlugin = WPPluginToolkitPlugin::create('WPLess', __FILE__, 'WPLessPlugin');
 
 	register_activation_hook(__FILE__, array($WPLessPlugin, 'install'));
 	register_deactivation_hook(__FILE__, array($WPLessPlugin, 'uninstall'));


### PR DESCRIPTION
Hello,

I successfully loaded a couple of LESS stylesheets and then I tried to register a LESS variable using PHP and got an error.

`Fatal error: Call to a member function addVariable() on a non-object in /websites/mulliganz/site/wp-content/themes/mulliganz/functions.php on line 54`

I copied and pasted the [example in the docs](https://github.com/oncletom/wp-less/wiki/Advanced-Usage) so I don't know why I'm seeing this error. Here's a copy of the code I posted in.

```
if (class_exists('WPLessPlugin'))
{
    $less = WPLessPlugin::getInstance();

    $less->addVariable('myColor', '#666');
    // you can now use @myColor in your *.less files

    $less->setVariables(array(
        'myColor' => '#777',
        'minSize' => '18px'
    ));
    // you can now use @minSize in your *.less files
    // @myColor value has been updated to #777
}
```

When I try to `print_r()` or `echo` out the $less variable I don't get anything what so ever. I assume the variable is empty. What's going on?

Note: I'm using this as a plugin. It is _not_ embedded within the theme.
