### PR TITLE
force compile if target file is missing

### DIFF
--- a/lib/Compiler.class.php
+++ b/lib/Compiler.class.php
@@ -71,6 +71,8 @@ class WPLessCompiler extends lessc
 	{
 		$cache_name = 'wp_less_compiled_'.md5($stylesheet->getSourcePath());
 		$compiled_cache = get_transient($cache_name);
+		
+		if( !$force && !file_exists( $stylesheet->getTargetPath() ) ) $force = true;
 
 		$compiled_cache = $this->cachedCompile($compiled_cache ? $compiled_cache : $stylesheet->getSourcePath(), $force);
 


### PR DESCRIPTION
This handles the case where garbage collection removes cached files and they are not recreated because the $compiled_cache variable tells the compiler it exists.
