### PR TITLE
unlink exception during utpdated files cleanup

### DIFF
--- a/lib/Garbagecollector.class.php
+++ b/lib/Garbagecollector.class.php
@@ -45,6 +45,7 @@ class WPLessGarbagecollector
 		$outdated = array();
 		$time = time();
 		$dir = new RecursiveDirectoryIterator($this->configuration->getUploadDir());
+        $dir->setFlags(RecursiveDirectoryIterator::SKIP_DOTS);
 
 		/*
 		 * Collecting CSS files


### PR DESCRIPTION
Hi,
I was using your plugin for a while and noticed some exceptions 
ErrorException [ Warning ]: unlink(/var/www/darth/html/wp-content/uploads/wp-less/my-theme/..): Is a directory

/var/www/wordpress-site/html/wp-content/plugins/wp-less/lib/Garbagecollector.class.php [ 118 ]

113      \* @param array $files
114      \* @return array
115      */
116     protected function deleteFiles(array $files)
117     {
118         return array_map('unlink', $files);
119     }
120 }

I've fixed the Error by adding:
$dir->setFlags(RecursiveDirectoryIterator::SKIP_DOTS); 
for RecursiveDirectoryIterator to skip the Dots during iteration.
