### PR TITLE
Fix an issue where garbage collection bloats DB

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -76,15 +76,19 @@ class WPLessPlugin extends WPPluginToolkitPlugin
      */
     public function install()
     {
-        // Check to see if it isn't scheduled first, for example
-        // this would occur when loaded via theme
+        /*
+         * Check to see if it isn't scheduled first, for example
+         * this would occur when loaded via theme
+         */
         if ( FALSE === wp_get_schedule( 'wp-less-garbage-collection' ) )
         {
             wp_schedule_event(time(), 'daily', 'wp-less-garbage-collection');
         }
 
-        // Clear old hooks, prior to hook change
-        // #57
+        /* 
+         * Clear old hooks, prior to hook change
+         * #57
+         */
         wp_clear_scheduled_hook( 'wp-less_garbage_collection' );
     }
 


### PR DESCRIPTION
There is an issue I keep hitting where the `cron` value in `wp_options`
get's so big that the site no longer operates.

I believe this could be due to an issue mentioned at
https://codex.wordpress.org/Function_Reference/wp_schedule_event

'For some reason there seems to be a problem on some systems where the
hook must not contain underscores or uppercase characters.'

The issue causes the hook to be repeatedly added to the serialised
array, which then means WordPress times out trying to communicate with
the database.

For backwards compatibility, would we also need to hook the old action into the newly labelled one?
