### PR TITLE
Check "is_ssl()" and change $uri

### DIFF
--- a/lib/vendor/plugin-toolkit/BaseConfiguration.class.php
+++ b/lib/vendor/plugin-toolkit/BaseConfiguration.class.php
@@ -289,6 +289,12 @@ abstract class WPPluginToolkitConfiguration
       }
     }
 
+    // If the request is https, make sure we generate a https url.
+    if( is_ssl() )
+    {
+      $url = str_replace( 'http://', 'https://', $url );
+    }
+
     $uploads = apply_filters('upload_dir', array(
       'path' =>     $dir,
       'url' =>      $url,


### PR DESCRIPTION
Our Server force SSL but WordPress does not understand it. So the
default URLs are not right. This change fixes this issue.
