### PR TITLE
Only load less-compiler with *require* if composer autoload is not present

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -43,8 +43,10 @@ class WPLessPlugin extends WPPluginToolkitPlugin
     
     public function instantiateCompiler()
     {
-        // Load the parent compiler class
-        require $this->getLessCompilerPath();
+        if (!class_exists('lessc')) {
+            // Load the parent compiler class
+            require $this->getLessCompilerPath();
+        }
         
         $this->compiler = new WPLessCompiler;
         $this->compiler->setVariable('stylesheet_directory_uri', "'" . get_stylesheet_directory_uri() . "'");


### PR DESCRIPTION
Use composers autoload to load lessc instead of define or hardcoding inside the plugin
