### PR TITLE
Enabling wp-less parsing in Admin Area

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -300,6 +300,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
 
         is_admin() ? do_action('wp-less_init_admin', $this) : do_action('wp-less_init', $this);
         add_action('wp_enqueue_scripts', array($this, 'processStylesheets'), 999, 0);
+        add_action('admin_enqueue_scripts', array($this, 'processStylesheets'), 999, 0);
         add_filter('wp-less_stylesheet_save', array($this, 'filterStylesheetUri'), 10, 2);
 
         return $this->is_hooks_registered = true;


### PR DESCRIPTION
"wp_enqueue_scripts" never get triggered in the admin area, we have to use "admin_enqueue_scripts"
