### PR TITLE
Change default compiler to oyejorge/less.php

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -65,7 +65,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
     {
         // The usage of the WP_LESS_COMPILER is a holdover from an older implentation
         // of this opt-in functionality
-        $compiler = defined('WP_LESS_COMPILER') ? WP_LESS_COMPILER : apply_filters('wp_less_compiler', 'lessphp');
+        $compiler = defined('WP_LESS_COMPILER') ? WP_LESS_COMPILER : apply_filters('wp_less_compiler', 'less.php');
 
         switch( $compiler ){
             case 'less.php':


### PR DESCRIPTION
Since the https://github.com/oyejorge/less.php compiler is more up to date and it's offical port for Less, I would recommend to use like a default one.

For example it supports passing ruleset into mixins:
```less
.mixin( { a: b; } );
```
And also http://lesscss.org/functions/#misc-functions-data-uri