### PR TITLE
Compressed output by default

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -53,7 +53,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
         $this->compiler = new WPLessCompiler;
         $this->compiler->setVariable('stylesheet_directory_uri', "'" . get_stylesheet_directory_uri() . "'");
         $this->compiler->setVariable('template_directory_uri', "'" . get_template_directory_uri() . "'");
-        if(!WP_DEBUG) { $this->compiler->setFormatter('compressed'); }
+        if(!defined('WP_DEBUG') || !WP_DEBUG) { $this->compiler->setFormatter('compressed'); }
     }
 
     /**

--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -53,6 +53,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
         $this->compiler = new WPLessCompiler;
         $this->compiler->setVariable('stylesheet_directory_uri', "'" . get_stylesheet_directory_uri() . "'");
         $this->compiler->setVariable('template_directory_uri', "'" . get_template_directory_uri() . "'");
+        if(!WP_DEBUG) $this->compiler->setFormatter('compressed');
     }
 
     /**

--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -53,7 +53,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
         $this->compiler = new WPLessCompiler;
         $this->compiler->setVariable('stylesheet_directory_uri', "'" . get_stylesheet_directory_uri() . "'");
         $this->compiler->setVariable('template_directory_uri', "'" . get_template_directory_uri() . "'");
-        if(!WP_DEBUG) $this->compiler->setFormatter('compressed');
+        if(!WP_DEBUG) { $this->compiler->setFormatter('compressed'); }
     }
 
     /**


### PR DESCRIPTION
It saves a lots of traffic.

For development mode full output is maintained.
