### PR TITLE
Better support for PHP 8.0

### DIFF
--- a/lib/Plugin.class.php
+++ b/lib/Plugin.class.php
@@ -309,7 +309,7 @@ class WPLessPlugin extends WPPluginToolkitPlugin
 
                 // Remove version from uri
                 $parts = parse_url( $style_sheet );
-                $style_sheet = $parts['scheme'] . '://' . $parts['host'] . (!$parts['port'] ? '' : (':' . $parts['port'])) .  $parts['path'];
+                $style_sheet = $parts['scheme'] . '://' . $parts['host'] . ((!isset($parts['port']) || !$parts['port']) ? '' : (':' . $parts['port'])) .  $parts['path'];
 
                 // Get extension and set handle for wp_register_style()
                 $pathinfo = pathinfo($style_sheet);


### PR DESCRIPTION
Here it is first checked whether port exists as a variable before it is used. In PHP 8.0 this throws warnings/hints otherwise.